### PR TITLE
fix: refactor from Closure in routes, onto controller method

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
-
+use \Bernhardh\NovaDynamicViews\Http\Controllers\NovaDynamicViewsController;
 /*
 |--------------------------------------------------------------------------
 | Tool API Routes
@@ -14,18 +14,4 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
- Route::get('{resource}/{method}', function (\Laravel\Nova\Http\Requests\ResourceDetailRequest $request, $resource, $method) {
-     $resourceClass = $request->resource();
-     $model = $request->model();
-     $method = \Illuminate\Support\Str::camel('custom-' . $method . '-components');
-     $resource = new $resourceClass($model);
-     
-     if(method_exists($resource, $method)) {
-        $data = $resource->$method();
-        if($data) {
-            return $data;
-        }
-     }
-     
-     return [];
- });
+ Route::get('{resource}/{method}', [NovaDynamicViewsController::class, 'resourceRequestDetails']);

--- a/src/Http/Controllers/NovaDynamicViewsController.php
+++ b/src/Http/Controllers/NovaDynamicViewsController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Bernhardh\NovaDynamicViews\Http\Controllers;
+
+use Illuminate\Routing\Controller;
+use \Laravel\Nova\Http\Requests\ResourceDetailRequest;
+use \Illuminate\Support\Str;
+/**
+ * Class NovaDynamicViewsController
+ * @package Bernhardh\NovaDynamicViews\Http\Controllers
+ */
+class NovaDynamicViewsController extends Controller
+{
+    /**
+     * @param ResourceDetailRequest $request
+     * @param $resource
+     * @param $method
+     * @return array
+     */
+    public function resourceRequestDetails(ResourceDetailRequest $request, $resource, $method) {
+        $resourceClass = $request->resource();
+        $model = $request->model();
+        $method = Str::camel('custom-' . $method . '-components');
+        $resource = new $resourceClass($model);
+
+        if(method_exists($resource, $method)) {
+            $data = $resource->$method();
+            if($data) {
+                return $data;
+            }
+        }
+
+        return [];
+    }
+}


### PR DESCRIPTION
Closures block possibility to cache routes. We should avoid closures in routing, and create controller methods instead.